### PR TITLE
bugfix and a proposal for an improvement

### DIFF
--- a/bin/forever
+++ b/bin/forever
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 var path = require('path'),
+
     fs = require('fs'),
     sys  = require('sys');
 
@@ -13,7 +14,7 @@ var argv = require('optimist').argv;
 
 require.paths.unshift(path.join(__dirname, '..', 'lib'));
 
-var forever = require('forever');
+var forever = require('../lib/forever.js');
 
 var help = [
     "usage: forever [start | stop | stopall | list | cleanlogs] [options] SCRIPT [script options]",
@@ -77,6 +78,11 @@ var file = argv._[0];
 var options = {};
 options.options = process.argv.splice(process.argv.indexOf(file)).splice(1);
 
+// Setup configurations for forever before using optimist otherwise it will modify argv! and p will become a boolean
+var config = {
+  root: argv.p
+};
+
 // Now that we've removed the target script options
 // reparse the options and setup the forever settings
 argv = require('optimist')(process.argv).argv;
@@ -91,10 +97,6 @@ if (typeof options['max'] === 'undefined') {
   options.forever = true;
 }
 
-// Setup configurations for forever
-var config = {
-  root: argv.p
-};
 
 function tryStart (callback) {
   var fullPath, uid = forever.randomString(16);

--- a/lib/forever.js
+++ b/lib/forever.js
@@ -13,7 +13,7 @@ var sys = require('sys'),
     events = require('events'),
     exec = require('child_process').exec,
     spawn = require('child_process').spawn,
-    daemon = require('daemon');
+    daemon = require('../../daemon/lib/daemon.js');
 
 var forever = exports, config;
 
@@ -80,6 +80,7 @@ forever.startDaemon = function (file, options) {
   fs.open(options.logFile, 'w+', function (err, fd) {
     try {
       var pid = daemon.start(fd);
+console.log('damon started');
       daemon.lock(options.pidFile);
       process.pid = pid;
       
@@ -90,6 +91,7 @@ forever.startDaemon = function (file, options) {
       // process.on('exit', function () {
       //   fs.unlinkSync(options.pidFile);
       // });
+console.log('damon started');
       
       runner.start().save().on('restart', function (fvr) { fvr.save() });
     }
@@ -418,7 +420,13 @@ var Forever = function (file, options) {
   else {
     this.options.unshift(file);
   }
-  
+//here we should enable some options to give to node itsself e.g.
+//debugging
+  //  this.options.unshift('--debug');
+//profiling
+  //  this.options.unshift('--prof');
+  //  this.options.unshift('--prof_lazy');
+console.log(sys.inspect(this.options))
   // If we should log stdout, open a file buffer 
   if (this.outFile) {
     this.stdout = fs.createWriteStream(this.outFile, { flags: 'a+', encoding: 'utf8', mode: 0666 });
@@ -441,14 +449,18 @@ sys.inherits(Forever, events.EventEmitter);
 //
 Forever.prototype.start = function (restart) {
   var self = this;
-  
+  console.log('damon started start');
+
   if (this.running && !restart) {
     process.nextTick(function () {
       self.emit('error', new Error('Cannot start process that is already running.'));
     });
   }
-  
+  console.log('damon started before spawn');
+
   var child = this.trySpawn();
+console.log('after spawn child: ', sys.inspect(child));
+
   if (!child) {
     process.nextTick(function () {
       self.emit('error', new Error('Target script does not exist: ' + self.options[0]));


### PR DESCRIPTION
Hi indexzero,
first off, great work!!! forever is to me the most comprehensive and flexible way of starting daemons, that I have ever seen.
There is a small bug in the command line script when used with a different path than /tmp/forever.
When you throw in optimist you overwrite argv, optimist transforms argv.p from path info to a boolean ;) 
so that config= {root:argv.p} becomes true, thus resulting in a fail of mkdir in forever.load.

I also have a proposal for an improvement which till now I fixed in a dirty way. Sometimes I would like to run node with some argument: e.g. node --prof app.js --some --args. The way forever works if used from command line, is that it looks for the first argument name 'node' and then automatically assumes, that the next argument is the script name. So for now I use it programmatically with forever.startDaemon  passing in an array. However sI still have to trick forever from beleiving the second argument is a script. Right now I am using an alias to node called 'nade' to trick forever in parsing the rest of the arguments in order. ;) which of course is not beautiful.

I think the easiest fix would be to not insist to much in the order of the arguments pushed. After all we are all professionals right ;)

Best regards

Gregor
