### PR TITLE
Keep on trying with spinning scripts

### DIFF
--- a/bin/forever
+++ b/bin/forever
@@ -30,18 +30,20 @@ var help = [
   '  cleanlogs        [CAREFUL] Deletes all historical forever log files',
   '',
   'options:',
-  '  -m MAX         Only run the specified script MAX times',
-  '  -l  LOGFILE    Logs the forever output to LOGFILE',
-  '  -o  OUTFILE    Logs stdout from child script to OUTFILE',
-  '  -e  ERRFILE    Logs stderr from child script to ERRFILE',
-  '  -d  SOURCEDIR  The source directory for which SCRIPT is relative to',
-  '  -p  PATH       Base path for all forever related files (pid files, etc.)',
-  '  -c  COMMAND    COMMAND to execute (defaults to node)',
-  '  --pidfile      The pid file',
-  '  -a, --append   Append logs',
-  '  -v, --verbose  Turns on the verbose messages from Forever',
-  '  -s, --silent   Run the child script silencing stdout and stderr',
-  '  -h, --help     You\'re staring at it',
+  '  -m MAX          Only run the specified script MAX times',
+  '  -l  LOGFILE     Logs the forever output to LOGFILE',
+  '  -o  OUTFILE     Logs stdout from child script to OUTFILE',
+  '  -e  ERRFILE     Logs stderr from child script to ERRFILE',
+  '  -d  SOURCEDIR   The source directory for which SCRIPT is relative to',
+  '  -p  PATH        Base path for all forever related files (pid files, etc.)',
+  '  -c  COMMAND     COMMAND to execute (defaults to node)',
+  '  --pidfile       The pid file',
+  '  -a, --append    Append logs',
+  '  --minUptime     Minimum uptime (millis) for a script to not be considered "spinning"',
+  '  --spinSleepTime Time to wait (millis) between launches of a spinning script.  (defaults to killing a spinning script).',
+  '  -v, --verbose   Turns on the verbose messages from Forever',
+  '  -s, --silent    Run the child script silencing stdout and stderr',
+  '  -h, --help      You\'re staring at it',
   '',
   '[Long Running Process]',
   '  The forever process will continue to run outputting log messages to the console.',
@@ -71,20 +73,22 @@ if (argv.h || argv.help || (argv._.length === 0 && !isSimpleAction())
 }
 
 var mappings = {
-  'c':       'command',
-  'e':       'errFile',
-  'd':       'sourceDir',
-  'l':       'logFile',
-  'a':       'appendLog',
-  'append':  'appendLog',
-  'm':       'max',
-  'o':       'outFile',
-  'p':       'path',
-  'pidfile': 'pidFile',
-  's':       'silent',
-  'silent':  'silent',
-  'v':       'verbose',
-  'verbose': 'verbose'  
+  'c':             'command',
+  'e':             'errFile',
+  'd':             'sourceDir',
+  'l':             'logFile',
+  'a':             'appendLog',
+  'append':        'appendLog',
+  'm':             'max',
+  'o':             'outFile',
+  'p':             'path',
+  'pidfile':       'pidFile',
+  's':             'silent',
+  'silent':        'silent',
+  'minUptime':     'minUptime',
+  'spinSleepTime': 'spinSleepTime',
+  'v':             'verbose',
+  'verbose':       'verbose'  
 };
 
 //
@@ -120,6 +124,13 @@ if (typeof options['max'] === 'undefined') {
   // If max isn't specified set it to run forever
   //
   options.forever = true;
+}
+
+if (typeof options['minUptime'] !== 'undefined') {
+    options['minUptime'] = parseFloat(options['minUptime']);
+}
+if (typeof options['spinSleepTime'] !== 'undefined') {
+    options['spinSleepTime'] = parseFloat(options['spinSleepTime']);
 }
 
 if (!options.sourceDir) {

--- a/lib/forever/monitor.js
+++ b/lib/forever/monitor.js
@@ -23,21 +23,22 @@ var sys = require('sys'),
 var Monitor = exports.Monitor = function (script, options) {
   events.EventEmitter.call(this);
   
-  options         = options || {};
-  this.silent     = options.silent || false;
-  this.forever    = options.forever || false;
-  this.command    = options.command || 'node';
-  this.sourceDir  = options.sourceDir;
-  this.minUptime  = typeof options.minUptime !== 'number' ? 2000 : options.minUptime;
-  this.options    = options.options || [];
-  this.spawnWith  = options.spawnWith || null;
-  this.uid        = options.uid || forever.randomString(24);
-  this.max        = options.max;
-  this.logFile    = options.logFile || path.join(forever.config.get('root'), this.uid + '.log');
-  this.pidFile    = options.pidFile || path.join(forever.config.get('pidPath'), this.uid + '.pid');
-  this.outFile    = options.outFile;
-  this.errFile    = options.errFile;
-  this.logger     = options.logger || new (winston.Logger)({
+  options            = options || {};
+  this.silent        = options.silent || false;
+  this.forever       = options.forever || false;
+  this.command       = options.command || 'node';
+  this.sourceDir     = options.sourceDir;
+  this.minUptime     = typeof options.minUptime !== 'number' ? 2000 : options.minUptime;
+  this.spinSleepTime = options.spinSleepTime || null;
+  this.options       = options.options || [];
+  this.spawnWith     = options.spawnWith || null;
+  this.uid           = options.uid || forever.randomString(24);
+  this.max           = options.max;
+  this.logFile       = options.logFile || path.join(forever.config.get('root'), this.uid + '.log');
+  this.pidFile       = options.pidFile || path.join(forever.config.get('pidPath'), this.uid + '.pid');
+  this.outFile       = options.outFile;
+  this.errFile       = options.errFile;
+  this.logger        = options.logger || new (winston.Logger)({
     transports: [new winston.transports.Console({ silent: this.silent })]
   });
   
@@ -140,23 +141,40 @@ Monitor.prototype.start = function (restart) {
   child.on('exit', function (code) {
     var spinning = Date.now() - self.ctime < self.minUptime;
     self.warn('Forever detected script exited with code: ' + code);
-    
-    if ((self.forever || self.times < self.max) && !self.forceStop && !spinning) {
+
+    function letChildDie() {
+      self.running = false;
+
+      // If had to write to an stdout file, close it
+      if (self.stdout) self.stdout.end();
+      // If had to write to an stderr file, close it
+      if (self.stderr) self.stderr.end();
+
+      self.emit('exit', self, spinning);
+    }
+
+    function restartChild() {
       self.times++;
       process.nextTick(function () {
         self.warn('Forever restarting script for ' + self.times + ' time');
         self.start(true);
       });
     }
+
+    if(self.forceStop) {
+      letChildDie();
+    }
+    else if(spinning && typeof self.spinSleepTime !== 'number') {
+      letChildDie();
+    }
+    else if (!self.forever && self.times >= self.max) {
+      letChildDie();
+    }
+    else if(spinning) {
+      setTimeout(restartChild, self.spinSleepTime);
+    }
     else {
-      this.running = false;
-      
-      // If had to write to an stdout file, close it
-      if (self.stdout) self.stdout.end();
-      // If had to write to an stderr file, close it
-      if (self.stderr) self.stderr.end();
-      
-      self.emit('exit', self, spinning);
+      restartChild();
     }
   });
   

--- a/test/spin-test.js
+++ b/test/spin-test.js
@@ -17,16 +17,34 @@ var sys = require('sys'),
 vows.describe('forever/spin-restart').addBatch({
   "When using forever": {
     "and spawning a script that spin restarts": {
-      topic: function () {
-        var script = path.join(__dirname, '..', 'examples', 'always-throw.js'),
-            child = new (forever.Forever)(script, { silent: true });
+      "with no spinSleepTime specified": {
+        topic: function () {
+          var script = path.join(__dirname, '..', 'examples', 'always-throw.js'),
+              child = new (forever.Forever)(script, { silent: true, max: 3 });
 
-        child.on('exit', this.callback.bind(null, null));
-        child.start();
+          child.on('exit', this.callback.bind({}, null));
+          child.start();
+        },
+        "should spawn both processes appropriately": function (err, child, spinning) {
+          assert.isTrue(spinning);
+        },
+        "should not restart spinning processes": function (err, child, spinning) {
+          assert.equal(child.times, 0);
+        }
       },
-      "should spawn both processes appropriately": function (err, monitor, spinning) {
-        assert.isTrue(spinning);
+
+      "with a spinSleepTime specified": {
+        topic: function () {
+          var script = path.join(__dirname, '..', 'examples', 'always-throw.js'),
+              child = new (forever.Forever)(script, { silent: true, max: 3, spinSleepTime: 1 });
+
+          child.on('exit', this.callback.bind({}, null));
+          child.start();
+        },
+        "should restart spinning processes": function (err, child, spinning) {
+          assert.equal(child.times, 3);
+        }
       }
     }
-  },
+  }
 }).export(module);


### PR DESCRIPTION
I think the pre-existing behavior (that lets spinning scripts die) is non-intuitive.

This commit exposes --minUptime to the CLI, and adds a new feature, 'spinSleepTime', that, if set, sleeps between restarts rather than killing a spinning script.

I don't like using "if set" logic very much.  I would have preferred:  default to a 60s spinSleepTime and add an option for the old behavior.  This is better from a "Principle of Least Surprise" point of view.  (I think least surprising would be a spinning script keeps getting restarted and chews up CPU, and users would put a "sleep 10" at the front of the script or something).

But, I didn't want to 'set policy' on your project, so I've left it such that not specifying these new command line options will not change behavior, in the hope that this means you're more likely to accept the patch :)

BTW:  A feature request I would really enjoy is log rotation.  I am paranoid that some of my chatty scripts will fill up disk and I will be surprised in a few months.
