### PR TITLE
Fix for broken stop & restart when path contains a number.

### DIFF
--- a/lib/forever.js
+++ b/lib/forever.js
@@ -38,7 +38,7 @@ forever.log.cli();
 // Export `version` and important Prototypes from `lib/forever/*`
 //
 forever.initialized = false;
-forever.root        = path.join(process.env.HOME, '.forever');
+forever.root        = path.join(process.env.HOME || '/root', '.forever');
 forever.config      = new nconf.stores.File({ file: path.join(forever.root, 'config.json') });
 forever.Forever     = forever.Monitor = require('./forever/monitor').Monitor;
 forever.cli         = require('./forever/cli');


### PR DESCRIPTION
that it should stop the script based on index instead of stopping
it based on script.

Removing the digit check solved this issue. If the index isn't found
it will return a `null` value and it will attempt to find the script
based by the target path which will pass.
