### PR TITLE
Allow default env variables to be hidden

### DIFF
--- a/lib/forever/monitor.js
+++ b/lib/forever/monitor.js
@@ -123,7 +123,7 @@ Monitor.prototype.start = function (restart) {
       self.emit('error', new Error('Cannot start process that is already running.'));
     });
   }
-
+  
   var child = this.trySpawn();
   if (!child) {
     process.nextTick(function () {
@@ -361,8 +361,7 @@ Monitor.prototype.kill = function (forceStop) {
 // to the target process spawned by this instance.
 //
 Monitor.prototype._getEnv = function () {
-  var self   = this,
-      merged = {};
+  var merged = {};
 
   function addKey (key, source) {
     merged[key] = source[key]
@@ -373,7 +372,7 @@ Monitor.prototype._getEnv = function () {
   // environment variables in `this.env`.
   //
   for(var k in process.env) {
-    if(!self.hideEnv[k]) {
+    if(!this.hideEnv[k]) {
       addKey(k, process.env);
     }
   }


### PR DESCRIPTION
Add an option.hideEnv hash to hide the specified environmental variables.

ex:

```
options = {...
   hideEnv: {
      SSH_CLIENT:true,
      SSH_CONNECTION:true
      }
...}
```
