### PR TITLE
Little trick, I don't know if is a global bug.

### DIFF
--- a/bin/forever
+++ b/bin/forever
@@ -113,7 +113,7 @@ var mappings = {
 // options, only use the first one. Assume the
 // rest are pass-through for the child process
 //
-var file = argv._[0], options = {};
+var file = argv._[1], options = {};
 
 if (file) {
   //


### PR DESCRIPTION
Edited line 116, Index 0 is the command, index 1 is the file. forever cmd was not working properly on my installation without this fix.
