### PR TITLE
ensure that child processes are also killed

### DIFF
--- a/lib/forever/monitor.js
+++ b/lib/forever/monitor.js
@@ -14,6 +14,7 @@ var util = require('util'),
     winston = require('winston'),
     watch = require('watch'),
     minimatch = require('minimatch'),
+    psTree = require('ps-tree'),
     forever = require('../forever');
 
 //
@@ -369,9 +370,14 @@ Monitor.prototype.kill = function (forceStop) {
     if (forceStop) {
       this.forceStop = true;
     }
+    psTree(this.child.pid, function (err, children) {
+      var pids = children.map(function (p) { return p.PID })
+      pids.shift(self.child.pid)
+      spawn('kill', ['-9'].concat(pids)).on('exit', function () {
+        self.emit('stop', self.childData);      
+      })
+    })
 
-    this.child.kill();
-    this.emit('stop', this.childData);
   }
 
   return this;

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "timespan": "2.0.x",
     "watch": "0.3.x",
     "minimatch": "0.0.x",
+    "ps-tree": "0.0.x",
     "winston": "0.5.x"
   },
   "devDependencies": {


### PR DESCRIPTION
the monitored process may spawn further processes, and in unix this can get messy.

this change will ensure that all the decendants get killed also.

uses https://github.com/dominictarr/ps-tree
