### PR TITLE
[monitor] .kill() should use callback

### DIFF
--- a/lib/forever/monitor.js
+++ b/lib/forever/monitor.js
@@ -339,17 +339,17 @@ Monitor.prototype.__defineGetter__('data', function () {
 // ### function restart ()
 // Restarts the target script associated with this instance.
 //
-Monitor.prototype.restart = function () {
+Monitor.prototype.restart = function (callback) {
   this.forceRestart = true;
-  return this.kill(false);
+  return this.kill(false, callback);
 };
 
 //
 // ### function stop ()
 // Stops the target script associated with this instance. Prevents it from auto-respawning
 //
-Monitor.prototype.stop = function () {
-  return this.kill(true);
+Monitor.prototype.stop = function (callback) {
+  return this.kill(true, callback);
 };
 
 //
@@ -357,12 +357,14 @@ Monitor.prototype.stop = function () {
 // #### @forceStop {boolean} Value indicating whether short circuit forever auto-restart.
 // Kills the ChildProcess object associated with this instance.
 //
-Monitor.prototype.kill = function (forceStop) {
+Monitor.prototype.kill = function (forceStop, callback) {
   var self = this;
 
   if (!this.child || !this.running) {
     process.nextTick(function () {
-      self.emit('error', new Error('Cannot stop process that is not running.'));
+      var err = new Error('Cannot stop process that is not running.');
+      callback && callback(err);
+      self.emit('error', err);
     });
   }
   else {
@@ -384,12 +386,14 @@ Monitor.prototype.kill = function (forceStop) {
 
         pids.unshift(self.child.pid);
         spawn('kill', ['-9'].concat(pids)).on('exit', function () {
+          callback && callback(null, self.childData);
           self.emit('stop', self.childData);
         });
       });
     }
     else {
       this.child.kill();
+      callback && callback(null, this.childData);
       this.emit('stop', this.childData);
     }
   }


### PR DESCRIPTION
`.restart()`, `.stop()` should take callback as optional argument, that's needed to fix some race-conditions in nodejitsu/haibu .
