### PR TITLE
Make sure all data is streamed before we try to parse it.

### DIFF
--- a/lib/forever.js
+++ b/lib/forever.js
@@ -93,7 +93,8 @@ function getAllProcesses(callback) {
 
   function getProcess(name, next) {
     var fullPath = path.join(sockPath, name),
-        socket = new net.Socket({ type: 'unix' });
+        socket = new net.Socket({ type: 'unix' }),
+        data = '';
 
     socket.on('error', function (err) {
       if (err.code === 'ECONNREFUSED') {
@@ -113,8 +114,12 @@ function getAllProcesses(callback) {
       next();
     });
 
-    socket.on('data', function (data) {
-      var monitors = JSON.parse(data.toString());
+    socket.on('data', function (msg) {
+      data += msg.toString();
+    });
+
+    socket.on('close', function () {
+      var monitors = JSON.parse(data);
       results.push.apply(results, monitors.monitors);
       next();
     });


### PR DESCRIPTION
It may happen that JSON string is split into more than one packet, in such case script was trying to parse just portion of received data and failed with parse error.

I was trying to cover it in tests, but unfortunately I'm not that familiar with project internals.
Anyway above issue is obvious, my application didn't work right cause of that.
