### PR TITLE
$'s in logFile names are annoying

### DIFF
--- a/lib/forever.js
+++ b/lib/forever.js
@@ -803,7 +803,7 @@ forever.cleanLogsSync = function (processes) {
 // length ⌈bits/6⌉ of characters from the base64 alphabet.
 //
 forever.randomString = function (bits) {
-  var chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_$',
+  var chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_',
       rand, i, ret = '';
 
   //


### PR DESCRIPTION
I like to tail the output of node programs while running them with forever. However, where there's a $ in the filename, I have to escape it otherwise bash thinks it's an env variable.

There should still be enough entropy in the generator without it, and we get to copy-paste log paths without thinking :)
