### PR TITLE
update watch dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "portfinder": "0.x.x",
     "ps-tree": "0.0.x",
     "timespan": "2.0.x",
-    "watch": "0.3.x",
+    "watch": "0.4.x",
     "winston": "0.5.x"
   },
   "devDependencies": {


### PR DESCRIPTION
from 0.3.x to 0.4.x.
0.4.x solved this issue:
https://github.com/indexzero/forever/issues/129
which was forever restarting continuously even without file changes.
