### PR TITLE
[test minor] Change `assert.length` to `assert.lengthOf`

### DIFF
--- a/test/multiple-processes-test.js
+++ b/test/multiple-processes-test.js
@@ -64,7 +64,7 @@ vows.describe('forever/multiple-processes').addBatch({
       },
       "should spawn both processes appropriately": function (err, data) {
         assert.isNull(err);
-        assert.length(data.monitors, 2);
+        assert.lengthOf(data.monitors, 2);
         this.child1.stop();
         this.child2.stop();
       }

--- a/test/tail-test.js
+++ b/test/tail-test.js
@@ -43,7 +43,7 @@ vows.describe('forever/tail').addBatch({
       },
       "should stop the correct number of procs": function (err, procs) {
         assert.isArray(procs);
-        assert.length(procs, 1);
+        assert.lengthOf(procs, 1);
       }
     }
   }


### PR DESCRIPTION
`vows@0.5.12` changes syntax from `assert.length` to `assert.lengthOf`.
