### PR TITLE
fix leading dashes in log and pid filenames

### DIFF
--- a/lib/forever.js
+++ b/lib/forever.js
@@ -322,7 +322,7 @@ forever.start = function (script, options) {
 //
 forever.startDaemon = function (script, options) {
   options         = options || {};
-  options.uid     = options.uid || utile.randomString(4);
+  options.uid     = options.uid || utile.randomString(4).replace(/^\-/, 'Qq');
   options.logFile = forever.logFilePath(options.logFile || options.uid + '.log');
   options.pidFile = forever.pidFilePath(options.pidFile || options.uid + '.pid');
 


### PR DESCRIPTION
Fix for issue #178, `utile.randomString` will give you a leading hypen in 1/64 uids and associated filenames.
