### PR TITLE
pidfile --> pidFile

### DIFF
--- a/examples/initd-example
+++ b/examples/initd-example
@@ -40,7 +40,7 @@ start() {
 
         # Launch the application
         start_daemon
-            $forever start -p $forever_dir --pidfile $pidfile -l $logfile -a -d $INSTANCE_DIR $SOURCE_NAME
+            $forever start -p $forever_dir --pidFile $pidfile -l $logfile -a -d $INSTANCE_DIR $SOURCE_NAME
         RETVAL=$?
     else
         echo "Instance already running"

--- a/lib/forever/cli.js
+++ b/lib/forever/cli.js
@@ -45,7 +45,7 @@ var help = [
   '  -p  PATH         Base path for all forever related files (pid files, etc.)',
   '  -c  COMMAND      COMMAND to execute (defaults to node)',
   '  -a, --append     Append logs',
-  '  --pidfile        The pid file',
+  '  --pidFile        The pid file',
   '  --sourceDir      The source directory for which SCRIPT is relative to',
   '  --minUptime      Minimum uptime (millis) for a script to not be considered "spinning"',
   '  --spinSleepTime  Time to wait (millis) between launches of a spinning script.',


### PR DESCRIPTION
as mentioned in #241, the cli help and initd example are currently using pidfile instead of pidFile, breaking the option of specifying a custom pid file.
