### PR TITLE
[api] forkShim option

### DIFF
--- a/lib/forever/monitor.js
+++ b/lib/forever/monitor.js
@@ -231,6 +231,9 @@ Monitor.prototype.trySpawn = function () {
     this.spawnWith.command = this.command;
     
     if (this.forkShim) {
+      if (typeof this.forkShim === 'string') {
+        this.spawnWith.forkModule = this.forkShim;
+      }
       this.spawnWith.env['FORK_SHIM'] = true;
       return nodeFork.shim.fork(this.args[0], this.args.slice(1), this.spawnWith);
     }


### PR DESCRIPTION
should allow a string to say which module to use when shimming (rather than the one currently used by this process)
