### PR TITLE
Fix worker crash from bad socket client

### DIFF
--- a/lib/forever/worker.js
+++ b/lib/forever/worker.js
@@ -37,6 +37,10 @@ Worker.prototype.start = function (callback) {
   // with a parent process.
   //
   function workerProtocol(socket) {
+    socket.on('error', function() {
+      socket.destroy();
+    })
+
     socket.data(['ping'], function () {
       socket.send(['pong']);
     });

--- a/test/worker/simple-test.js
+++ b/test/worker/simple-test.js
@@ -47,6 +47,25 @@ vows.describe('forever/worker/simple').addBatch({
         'it should kill the process': function (monitor) {
           assert.isFalse(monitor.running);
         }
+      },
+      'and when quickly sending data and disconnecting': {
+        topic: function(reader) {
+          var self = this;
+
+          // Need to connect second reader, otherwise it breaks the other
+          // tests as the reader is shared with them.
+          var reader2 = new nssocket.NsSocket();
+          reader2.connect(reader.host, function() {
+            reader2.send(['data']);
+            reader2.destroy();
+
+            setTimeout(self.callback, 100);
+          });
+        },
+        'it should not crash the worker': function(worker) {
+          // no asserition, everything is good if the test does not cause
+          // a worker crash.
+        }
       }
     })
   }


### PR DESCRIPTION
This bug fixes a problem caused by a socket client quickly disconnecting
after requesting 'data' from a worker socket. I have so far been unable
to track down what has been causing this bad client behavior, but it
seems sensible that a socket client should not be able to crash a worker
like this, so I hope this gets merged.
