### PR TITLE
Small typo in restart message

### DIFF
--- a/lib/forever.js
+++ b/lib/forever.js
@@ -779,7 +779,7 @@ forever.logEvents = function (monitor) {
   });
   
   monitor.on('watch:restart', function (info) {
-    console.error('restaring script because ' + info.file + ' changed')
+    console.error('restarting script because ' + info.file + ' changed')
   });
   
   monitor.on('restart', function () {


### PR DESCRIPTION
Fixed a small typo ("restaring" => "restarting".)
