### PR TITLE
Updated flatiron dependency to 0.2.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "cliff": "0.1.8",
-    "flatiron": "0.2.3",
+    "flatiron": "0.2.8",
     "forever-monitor": "1.0.2",
     "nconf": "0.6.1",
     "nssocket": "0.3.8",


### PR DESCRIPTION
This way it's possible to install forever on box that only has access to npm.

Flatiron 0.2.3 depends on prompt 0.2.2, that depends on read this way:

```
    "read": "https://github.com/indexzero/read/tarball/refactor-optional-streams",
```
