### PR TITLE
Fix uids mistakenly taken for an id

### DIFF
--- a/lib/forever.js
+++ b/lib/forever.js
@@ -555,7 +555,10 @@ forever.tail = function (target, length, callback) {
 // Finds the process with the specified index.
 //
 forever.findByIndex = function (index, processes) {
-  var proc = processes && processes[parseInt(index, 10)];
+  var indexAsNum = parseInt(index, 10);
+  if (indexAsNum == index) {
+    var proc = processes && processes[indexAsNum];
+  }
   return proc ? [proc] : null;
 };
 


### PR DESCRIPTION
When an uid starts with a number, forever think it is an index and apply the action to the wrong task.
For example `forever restart 7wFU` restarts the task at index 7 instead of the the task with the uid forever restart 7wFU.
This pull request fixes it.
