### PR TITLE
Windows compatibility

### DIFF
--- a/lib/forever.js
+++ b/lib/forever.js
@@ -40,7 +40,7 @@ forever.log.cli();
 forever.initialized  = false;
 forever.kill         = require('forever-monitor').kill;
 forever.checkProcess = require('forever-monitor').checkProcess;
-forever.root         = path.join(process.env.HOME || '/root', '.forever');
+forever.root         = path.join(process.env.HOME || process.env.USERPROFILE || '/root', '.forever');
 forever.config       = new nconf.File({ file: path.join(forever.root, 'config.json') });
 forever.Forever      = forever.Monitor = require('forever-monitor').Monitor;
 forever.Worker       = require('./forever/worker').Worker;


### PR DESCRIPTION
On Windows there is no  `process.env.HOME`, Windows defines `USERPROFILE` instead. 

Unfortunately there is a bigger problem on Windows. See my comment on https://github.com/nodejitsu/forever/issues/337
