### PR TITLE
Custom exit signal support

### DIFF
--- a/lib/forever/cli.js
+++ b/lib/forever/cli.js
@@ -190,7 +190,7 @@ var getOptions = cli.getOptions = function (file) {
   [
     'pidFile', 'logFile', 'errFile', 'watch', 'minUptime', 'append',
     'silent', 'outFile', 'max', 'command', 'path', 'spinSleepTime', 
-    'sourceDir', 'uid', 'watchDirectory', 'killTree'
+    'sourceDir', 'uid', 'watchDirectory', 'killTree', 'killSignal'
   ].forEach(function (key) {
     options[key] = app.config.get(key);
   });


### PR DESCRIPTION
Some time ago I needed forever to be able to shutdown my app gracefully. And I found no support of custom signal setting. I saw this feature requested in #320.

I've made changes in `forever-monitor`: https://github.com/nodejitsu/forever-monitor/pull/12
And now I've made one-line commit to forever to make it support the feature.
