### PR TITLE
Add options to control delay between script restarts.

### DIFF
--- a/lib/forever.js
+++ b/lib/forever.js
@@ -785,6 +785,10 @@ forever.logEvents = function (monitor) {
     console.error('restarting script because ' + info.file + ' changed')
   });
   
+  monitor.on('restart:delay', function(delay) {
+    console.error('Forever will restart script in ' + delay + ' milliseconds');
+  });
+  
   monitor.on('restart', function () {
     console.error('Forever restarting script for ' + monitor.times + ' time')
   });

--- a/lib/forever/cli.js
+++ b/lib/forever/cli.js
@@ -49,6 +49,10 @@ var help = [
   '  --sourceDir      The source directory for which SCRIPT is relative to',
   '  --minUptime      Minimum uptime (millis) for a script to not be considered "spinning"',
   '  --spinSleepTime  Time to wait (millis) between launches of a spinning script.',
+  '  --delay          Time to wait (millis) between restarting a stopped script.',
+  '  --delayAlgorithm Algorithm used to compute delay between each restart attempt.',
+  '                     (incremental [default], exponential, fibonacci)',
+  '  --delayMax       The maximum time (millis) to wait between restart attempts.',
   '  --plain          Disable command line colors',
   '  -d, --debug      Forces forever to log debug output',
   '  -v, --verbose    Turns on the verbose messages from Forever',
@@ -100,7 +104,8 @@ var argvOptions = cli.argvOptions = {
   'verbose':   {alias: 'v', boolean: true},
   'watch':     {alias: 'w', boolean: true},
   'debug':     {alias: 'd', boolean: true},
-  'plain':     {boolean: true}
+  'plain':     {boolean: true},
+  'delay':     {alias: 'D'}
 };
 
 app.use(flatiron.plugins.cli, {
@@ -188,8 +193,9 @@ var getOptions = cli.getOptions = function (file) {
   app.config.use('argv', argvOptions);
 
   [
-    'pidFile', 'logFile', 'errFile', 'watch', 'minUptime', 'append',
-    'silent', 'outFile', 'max', 'command', 'path', 'spinSleepTime', 
+    'pidFile', 'logFile', 'errFile', 'watch', 'minUptime',
+    'delay', 'delayAlgorithm', 'delayMax',
+    'append', 'silent', 'outFile', 'max', 'command', 'path', 'spinSleepTime', 
     'sourceDir', 'uid', 'watchDirectory', 'killTree'
   ].forEach(function (key) {
     options[key] = app.config.get(key);


### PR DESCRIPTION
This pull request along with changes to [forever-monitor](https://github.com/nodejitsu/forever-monitor/pull/15) provides options to add a delay between restarting a script.

This implements the feature request in issue [#350](https://github.com/nodejitsu/forever/issues/350).
The user can set a delay in milliseconds and increase it by using a configurable algorithm.
See the PR for forever-monitor for more details on these algorithms.
