### PR TITLE
always use full paths when starting scripts

### DIFF
--- a/lib/forever/cli.js
+++ b/lib/forever/cli.js
@@ -221,7 +221,7 @@ app.cmd('cleanlogs', cli.cleanLogs = function () {
 // process.
 //
 app.cmd(/start (.+)/, cli.startDaemon = function () {
-  var file = app.argv._[1],
+  var file = process.env.PWD + '/' + app.argv._[1].replace(/^.+\//, ''),
       options = getOptions(file);
 
   forever.log.info('Forever processing file: ' + file.grey);
@@ -492,7 +492,7 @@ app.cmd('help', cli.help = function () {
 // make executing other commands possible.
 //
 cli.run = function () {
-  var file = app.argv._[0],
+  var file = process.env.PWD + '/' + app.argv._[0].replace(/^.+\//, ''),
       options = getOptions(file);
 
   tryStart(file, options, function () {


### PR DESCRIPTION
In response to [this issue](https://github.com/nodejitsu/forever/issues/364).

There are two downsides I can see to this.

One is that the command-line output of `forever list` will now be a little bulkier.

The other is that some people might currently rely on the ability to stop identically-named scripts with a single command. However, that would mean they're relying on undocumented functionality that could be classified as a bug anyway.
