### PR TITLE
Update lib/forever.js

### DIFF
--- a/lib/forever.js
+++ b/lib/forever.js
@@ -418,6 +418,8 @@ forever.startDaemon = function (script, options) {
 
   monitor.send(JSON.stringify(options));
   monitor.unref();
+  
+  return monitor;
 };
 
 //


### PR DESCRIPTION
I think startDaemon() should return the monitor of the spawned process as otherwise there is no way of getting a reference on the child process when using startDaemon() programatically.
