### PR TITLE
return child process in forever.startDaemon()

### DIFF
--- a/lib/forever.js
+++ b/lib/forever.js
@@ -418,6 +418,8 @@ forever.startDaemon = function (script, options) {
 
   monitor.send(JSON.stringify(options));
   monitor.unref();
+  
+  return monitor;
 };
 
 //


### PR DESCRIPTION
Just provide some extra flexibility for using it in other node programs. (e.g. I wanted to get the pid of the spawned process)
