### PR TITLE
add no process error handling to cli.restartAll()

### DIFF
--- a/lib/forever/cli.js
+++ b/lib/forever/cli.js
@@ -273,8 +273,8 @@ app.cmd('stopall', cli.stopall = function () {
 });
 
 //
-// ### function stopall ()
-// Stops all currently running forever processes.
+// ### function restartall ()
+// Restarts all currently running forever processes.
 //
 app.cmd('restartall', cli.restartAll = function () {
   var runner = forever.restartAll(true);
@@ -288,6 +288,10 @@ app.cmd('restartall', cli.restartAll = function () {
     else {
       forever.log.info('No forever processes running');
     }
+  });
+
+  runner.on('error', function () {
+    forever.log.info('No forever processes running');
   });
 });
 


### PR DESCRIPTION
If you run `forever restartall` when no process is running you get an unhandled error event from the runner.

Also fixed the copy-pasted comments.
