### PR TITLE
checks proc.running and writes STOPPED instead of uptime if stopped

### DIFF
--- a/lib/forever.js
+++ b/lib/forever.js
@@ -858,7 +858,7 @@ forever.columns = {
   uptime: {
     color: 'yellow',
     get: function (proc) {
-      return timespan.fromDates(new Date(proc.ctime), new Date()).toString().yellow;
+      return proc.running ? timespan.fromDates(new Date(proc.ctime), new Date()).toString().yellow : "STOPPED".red;
     }
   }
 };


### PR DESCRIPTION
This change is semi-dependant on the forever-monitor request I submitted

https://github.com/nodejitsu/forever-monitor/pull/22

It checks for the process.running flag and returns the uptime as either the uptime or 'STOPPED' to indicate that the process has crashed out.
