### PR TITLE
Add the --watchIgnore option to the cli

### DIFF
--- a/lib/forever/cli.js
+++ b/lib/forever/cli.js
@@ -55,6 +55,7 @@ var help = [
   '  -s, --silent     Run the child script silencing stdout and stderr',
   '  -w, --watch      Watch for file changes',
   '  --watchDirectory Top-level directory to watch from',
+  '  --watchIgnore    To ignore pattern when watch is enabled (multiple option is allowed)',
   '  -h, --help       You\'re staring at it',
   '',
   '[Long Running Process]',
@@ -191,10 +192,13 @@ var getOptions = cli.getOptions = function (file) {
   [
     'pidFile', 'logFile', 'errFile', 'watch', 'minUptime', 'append',
     'silent', 'outFile', 'max', 'command', 'path', 'spinSleepTime', 
-    'sourceDir', 'uid', 'watchDirectory', 'killTree', 'killSignal'
+    'sourceDir', 'uid', 'watchDirectory', 'watchIgnore', 'killTree', 'killSignal'
   ].forEach(function (key) {
     options[key] = app.config.get(key);
   });
+  
+  options.watchIgnore         = options.watchIgnore || [ ];
+  options.watchIgnorePatterns = (options.watchIgnore instanceof Array) ? options.watchIgnore : [ options.watchIgnore ];
 
   options.sourceDir = options.sourceDir || (file && file[0] !== '/' ? process.cwd() : '/');
   if (options.sourceDir) {


### PR DESCRIPTION
When --watch is enabled, it was not possible to ignore files or directories. The option --watchIgnore will setup the --watchIgnorePatterns parameter to forever-monitor.

Usage example:
 --watchIgnore "_.log"  --watchIgnore "_.pid"  --watchIgnore "tmp/"
