### PR TITLE
Reverting proper behaviour of -v flag

### DIFF
--- a/lib/forever.js
+++ b/lib/forever.js
@@ -55,6 +55,8 @@ forever.Forever      = forever.Monitor = require('forever-monitor').Monitor;
 forever.Worker       = require('./forever/worker').Worker;
 forever.cli          = require('./forever/cli');
 
+
+
 //
 // Expose version through `pkginfo`
 //

--- a/lib/forever/cli.js
+++ b/lib/forever/cli.js
@@ -538,10 +538,6 @@ cli.run = function () {
 };
 
 cli.start = function () {
-  if (app.argv.v || app.argv.version) {
-    return console.log('v' + forever.version);
-  }
-
   //
   // Check for --no-colors/--colors and --plain option
   //


### PR DESCRIPTION
This reverts commit 1a1ba32dcab559b7c716edf16534fc0481a58e46 as discussed in https://github.com/nodejitsu/forever/issues/410
