### PR TITLE
Fixed watchIgnorePatterns assignment

### DIFF
--- a/lib/forever/cli.js
+++ b/lib/forever/cli.js
@@ -204,7 +204,7 @@ var getOptions = cli.getOptions = function (file) {
   });
 
   options.watchIgnore         = options.watchIgnore || [];
-  options.watchIgnorePatterns = !Array.isArray(options.watchIgnore)
+  options.watchIgnorePatterns = Array.isArray(options.watchIgnore)
     ? options.watchIgnore
     : [options.watchIgnore];
 


### PR DESCRIPTION
Default value for watchIgnorePatterns should be [], right now it's [ [] ] which breaks further code in forever-monitor watch.js file :

```
function watchFilter(fileName) {
  ...
  for (i = 0; i < length; i++) {
    testName = (this.watchIgnorePatterns[i].charAt(0) !== '/') ? relFileName : fileName;
    // this.watchIgnorePatterns[i] should be an String instance. Empty array breaks this code !
```
