### PR TITLE
Added support to run 'forever start' in a directory without a filename

### DIFF
--- a/lib/forever/cli.js
+++ b/lib/forever/cli.js
@@ -246,9 +246,23 @@ app.cmd('cleanlogs', cli.cleanLogs = function () {
 // Starts a forever process for the script located at `file` as daemon
 // process.
 //
-app.cmd(/start (.+)/, cli.startDaemon = function () {
+app.cmd(/start ?(.*)/, cli.startDaemon = function () {
   var file = app.argv._[1],
+      existsSync = (typeof fs.existsSync == 'function') ? fs.existsSync : path.existsSync,
       options = getOptions(file);
+
+  // If no file param is passed in, read the pankage.json to get the apps entry point
+  if(!file) {
+    if(existsSync(path.join(process.cwd(), 'package.json'))) {
+      forever.log.info('No filename provided, grabbing default entrypoint from package.json');
+      var packageObj = require(path.join(process.cwd(), 'package.json'));
+
+      file = require.resolve(packageObj.name);
+    } else {
+      forever.log.error('Cannot start forever: No filename provided, and no package.json found in this directory');
+      process.exit(-1);
+    }
+  }
 
   forever.log.info('Forever processing file: ' + file.grey);
   tryStart(file, options, function () {


### PR DESCRIPTION
Forever can now grab the entry point from package.json dynamically when no file name/path is given
