### PR TITLE
fixed wrong usage for option fifo

### DIFF
--- a/lib/forever/cli.js
+++ b/lib/forever/cli.js
@@ -97,7 +97,7 @@ var argvOptions = cli.argvOptions = {
   'errFile':   {alias: 'e'},
   'logFile':   {alias: 'l'},
   'append':    {alias: 'a', boolean: true},
-  'fifo':      {alias: 'f', boolean: false},
+  'fifo':      {alias: 'f', boolean: true},
   'number':    {alias: 'n'},
   'max':       {alias: 'm'},
   'outFile':   {alias: 'o'},


### PR DESCRIPTION
I doubt no one used fifo option so far. (it looks like not working as expected)
"optimist" expects boolean: true for boolean args.

After the fix:

forever logs 0 == tail $logfile
forever logs -f 0 == tail -f $logfile

regards,
