### PR TITLE
add "startall" action

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ You can use forever to run any kind of script continuously (whether it is writte
 
   actions:
     start               Start SCRIPT as a daemon
+    startall            Start all pre-configured scripts from config.apps
     stop                Stop the daemon SCRIPT
     stopall             Stop all running forever scripts
     restart             Restart the daemon SCRIPT
@@ -40,8 +41,10 @@ You can use forever to run any kind of script continuously (whether it is writte
     logs                Lists log files for all forever processes
     logs <script|index> Tails the logs for <script|index>
     columns add <col>   Adds the specified column to the output in `forever list`
-    columns rm <col>    Removed the specified column from the output in `forever list`
+    columns rm <col>    Removes the specified column from the output in `forever list`
     columns set <cols>  Set all columns for the output in `forever list`
+    apps add <script>   Adds the specified script to config.apps
+    apps rm <script>    Removes the specified script from config.apps
     cleanlogs           [CAREFUL] Deletes all historical forever log files
 
   options:
@@ -64,6 +67,7 @@ You can use forever to run any kind of script continuously (whether it is writte
     -s, --silent     Run the child script silencing stdout and stderr
     -w, --watch      Watch for file changes
     --watchDirectory Top-level directory to watch from
+    -r, --remember   Save the specified script to config.apps (only work with `start` action)
     -h, --help       You're staring at it
 
   [Long Running Process]

--- a/lib/forever/cli.js
+++ b/lib/forever/cli.js
@@ -23,6 +23,7 @@ var help = [
   '',
   'actions:',
   '  start               Start SCRIPT as a daemon',
+  '  startall            Start all pre-configured scripts from config.apps',
   '  stop                Stop the daemon SCRIPT',
   '  stopall             Stop all running forever scripts',
   '  restart             Restart the daemon SCRIPT',
@@ -34,8 +35,10 @@ var help = [
   '  logs                Lists log files for all forever processes',
   '  logs <script|index> Tails the logs for <script|index>',
   '  columns add <col>   Adds the specified column to the output in `forever list`',
-  '  columns rm <col>    Removed the specified column from the output in `forever list`',
+  '  columns rm <col>    Removes the specified column from the output in `forever list`',
   '  columns set <cols>  Set all columns for the output in `forever list`',
+  '  apps add <script>   Adds the specified script to config.apps',
+  '  apps rm <script>    Removes the specified script from config.apps',
   '  cleanlogs           [CAREFUL] Deletes all historical forever log files',
   '',
   'options:',
@@ -60,6 +63,7 @@ var help = [
   '  -w, --watch      Watch for file changes',
   '  --watchDirectory Top-level directory to watch from',
   '  --watchIgnore    To ignore pattern when watch is enabled (multiple option is allowed)',
+  '  -r, --remember   Save the specified script to config.apps (only work with `start` action)',
   '  -h, --help       You\'re staring at it',
   '',
   '[Long Running Process]',
@@ -79,6 +83,7 @@ var app = flatiron.app;
 
 var actions = [
   'start',
+  'startall',
   'stop',
   'stopall',
   'restart',
@@ -89,7 +94,8 @@ var actions = [
   'clear',
   'logs',
   'columns',
-  'cleanlogs'
+  'cleanlogs',
+  'apps'
 ];
 
 var argvOptions = cli.argvOptions = {
@@ -107,7 +113,8 @@ var argvOptions = cli.argvOptions = {
   'verbose':   {alias: 'v', boolean: true},
   'watch':     {alias: 'w', boolean: true},
   'debug':     {alias: 'd', boolean: true},
-  'plain':     {boolean: true}
+  'plain':     {boolean: true},
+  'remember':  {alias: 'r', boolean: true}
 };
 
 app.use(flatiron.plugins.cli, {
@@ -139,7 +146,7 @@ function tryStart(file, options, callback) {
       process.exit(-1);
     }
 
-    callback();
+    callback(file, options);
   });
 }
 
@@ -175,19 +182,8 @@ function checkColumn(name) {
   return true;
 }
 
-//
-// ### function getOptions (file)
-// #### @file {string} File to run. **Optional**
-// Returns `options` object for use with `forever.start` and
-// `forever.startDaemon`
-//
-var getOptions = cli.getOptions = function (file) {
+function getOptionsFromAppConfig() {
   var options = {};
-  //
-  // First isolate options which should be passed to file
-  //
-  options.options = process.argv.splice(process.argv.indexOf(file) + 1);
-
   //
   // Now we have to force optimist to reparse command line options because
   // we've removed some before.
@@ -220,6 +216,21 @@ var getOptions = cli.getOptions = function (file) {
       'at least ' + options.minUptime + 'ms'
     ].join(' '));
   }
+  return options;
+}
+
+//
+// ### function getOptions (file)
+// #### @file {string} File to run. **Optional**
+// Returns `options` object for use with `forever.start` and
+// `forever.startDaemon`
+//
+var getOptions = cli.getOptions = function (file) {
+  var options = getOptionsFromAppConfig();
+  //
+  // First isolate options which should be passed to file
+  //
+  options.options = process.argv.splice(process.argv.indexOf(file) + 1);
 
   options.sourceDir = options.sourceDir || (file && file[0] !== '/' ? process.cwd() : '/');
   if (options.sourceDir) {
@@ -250,6 +261,10 @@ app.cmd(/start (.+)/, cli.startDaemon = function () {
   var file = app.argv._[1],
       options = getOptions(file);
 
+  if (app.argv.remember) {
+    cli.addApp(file);
+  }
+
   forever.log.info('Forever processing file: ' + file.grey);
   tryStart(file, options, function () {
     forever.startDaemon(file, options);
@@ -273,6 +288,32 @@ app.cmd(/stop (.+)/, cli.stop = function (file) {
     forever.log.error('Forever cannot find process with index: ' + file);
     process.exit(1);
   });
+});
+
+//
+// ### function start ()
+// Starts all listed in config.apps as daemon processes.
+//
+app.cmd('startall', cli.startall = function () {
+  var apps = forever.config.get("apps") || [];
+  var empty = true;
+  for (var i in apps) {
+    empty = false;
+
+    var options = getOptionsFromAppConfig();
+    options.command = apps[i].command || undefined;
+    options.options = apps[i].options || [];
+    options.sourceDir = apps[i].sourceDir || "/";
+    var file = apps[i].script;
+
+    forever.log.info('Forever processing file: ' + file.grey);
+    tryStart(file, options, function (file, options) {
+      forever.startDaemon(file, options);
+    });
+  }
+  if (empty) {
+    forever.log.info('Forever nothing to start');
+  }
 });
 
 //
@@ -505,6 +546,49 @@ app.cmd(/columns set (.*)/, cli.setColumns = function (columns) {
   forever.log.info('Setting columns: ' + columns.magenta);
 
   forever.config.set('columns', columns.split(' '));
+  forever.config.saveSync();
+});
+
+function findApp(appConf) {
+  var apps = forever.config.get('apps') || [];
+  if (apps.length == 0)
+    return -1;
+  for (var i in apps) {
+    if ( JSON.stringify(apps[i]) === JSON.stringify(appConf) )
+      return i;
+  }
+  return -1;
+}
+
+app.cmd(/apps add (.+)/, cli.addApp = function (apppath) {
+  console.log("cli.addApp", apppath);
+  var abspath = path.resolve(apppath);
+  var apps = forever.config.get('apps') || [];
+
+  var appConf = {script: abspath};
+  if (findApp(appConf) >= 0)
+    return forever.log.warn(abspath.magenta + ' already exists in forever');
+
+  forever.log.info('Adding app: ' + abspath.magenta);
+  apps.push(appConf);
+
+  forever.config.set('apps', apps);
+  forever.config.saveSync();
+});
+
+app.cmd(/apps rm (.+)/, cli.rmApp = function (apppath) {
+  var abspath = path.resolve(apppath);
+  var apps = forever.config.get('apps') || [];
+
+  var appConf = {script: abspath};
+  var found = findApp(appConf);
+  if (found == -1)
+    return forever.log.warn(abspath.magenta + ' doesn\'t exist in forever');
+
+  forever.log.info('Removing app: ' + abspath.magenta);
+  apps.splice(found, 1);
+
+  forever.config.set('apps', apps);
   forever.config.saveSync();
 });
 


### PR DESCRIPTION
I would like to introduce "startall" action to forever.
This change lets forever be able to save a list of daemon settings in config.json and use "forever startall" to start all of them in 1 command.

This definitely helps managing multiple forever-ready daemons in 1 local server and reduces the risk of mis-operations.

Daemon list is saved in config.json like below:

```
{
    root: '/aaa/bbb',
    ...
    columns: [ ... ],
    apps: [
        { script: '/xxx/yyy', options: [ ... ] },
        { script: '...' }
    ]
}
```

Also there are 2 new actions to help adding/removing the list:

```
forever apps add /xxx/yyy...
forever apps rm /xxx/yyy...
```

Please let me know your thoughts.
Regards,
