### PR TITLE
Adding 'stopbypid' command for forever

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ You can use forever to run any kind of script continuously (whether it is writte
     start               Start SCRIPT as a daemon
     stop                Stop the daemon SCRIPT
     stopall             Stop all running forever scripts
-    stoppid             Stop running forever script by pid
+    stopbypid           Stop running forever script by pid
     restart             Restart the daemon SCRIPT
     restartall          Restart all running forever scripts
     list                List all running forever scripts

--- a/lib/forever.js
+++ b/lib/forever.js
@@ -553,12 +553,12 @@ forever.restart = function (target, format) {
 };
 
 //
-// ### function stoppid (target, format)
+// ### function stopbypid (target, format)
 // #### @pid {string} Pid of process to stop.
 // #### @format {boolean} Indicated if we should CLI format the returned output.
 // Stops the process with specified pid 
 //
-forever.stoppid = function (pid, format) {
+forever.stopbypid = function (pid, format) {
   // stopByPid only capable of stopping, but can't restart
   return stopByPid('stop', format, pid);
 };

--- a/lib/forever/cli.js
+++ b/lib/forever/cli.js
@@ -25,7 +25,7 @@ var help = [
   '  start               Start SCRIPT as a daemon',
   '  stop                Stop the daemon SCRIPT',
   '  stopall             Stop all running forever scripts',
-  '  stoppid             Stop running forever script by pid',
+  '  stopbypid           Stop running forever script by pid',
   '  restart             Restart the daemon SCRIPT',
   '  restartall          Restart all running forever scripts',
   '  list                List all running forever scripts',
@@ -81,7 +81,7 @@ var app = flatiron.app;
 var actions = [
   'start',
   'stop',
-  'stoppid',
+  'stopbypid',
   'stopall',
   'restart',
   'restartall',
@@ -278,11 +278,11 @@ app.cmd(/stop (.+)/, cli.stop = function (file) {
 });
 
 //
-// ### function stoppid (pid)
+// ### function stopbypid (pid)
 // Stops running forever process by pid.
 //
-app.cmd(/stoppid (.+)/, cli.stoppid = function (pid) {
-  var runner = forever.stoppid(pid, true);
+app.cmd(/stopbypid (.+)/, cli.stopbypid = function (pid) {
+  var runner = forever.stopbypid(pid, true);
 
   runner.on('stop', function (process) {
     forever.log.info('Forever stopped process:');


### PR DESCRIPTION
As requested in [issue 492](https://github.com/nodejitsu/forever/issues/492). 

I've decided to add 'stopbypid' command to **forever** for convenience. 
Even though name is not as good as i want it to be...it is still ok (i think). 

Example of this command usage:

``` bash
forever stopbypid 1239
```
