### PR TITLE
"forever start" hangs with node 0.11.9

### DIFF
--- a/lib/forever.js
+++ b/lib/forever.js
@@ -417,7 +417,16 @@ forever.startDaemon = function (script, options) {
   });
 
   monitor.send(JSON.stringify(options));
+  
+  // close the ipc communication channel with the monitor
+  // otherwise the corresponding events listeners will prevent 
+  // the exit of the current process (observed with node 0.11.9)
+  monitor.disconnect();
+  
+  // make sure the monitor is unref() and does not prevent the
+  // exit of the current process
   monitor.unref();
+  
   return monitor;
 };
 


### PR DESCRIPTION
node.js documentation states that unref() is necessary to release the parent but the example is for "ignore"

when the stdio type is 'ipc', additional listeners are setup that keep references to the child and prevent the exit of the parent process. http://nodejs.org/api/child_process.html#child_process_child_disconnect
