### PR TITLE
[windows] socket port numbers

### DIFF
--- a/lib/forever.js
+++ b/lib/forever.js
@@ -95,7 +95,7 @@ function getAllProcesses(callback) {
   var sockPath = forever.config.get('sockPath');
 
   function getProcess(name, next) {
-    var fullPath = path.join(sockPath, name),
+    var fullPath = /^\d+$/.test(name) ? name : path.join(sockPath, name),
         socket = new nssocket.NsSocket();
 
     socket.connect(fullPath, function (err) {

--- a/lib/forever/worker.js
+++ b/lib/forever/worker.js
@@ -100,7 +100,15 @@ Worker.prototype.start = function (callback) {
 
       callback && callback(err);
     });
-    
+
+    if (process.platform === 'win32') {
+      nssocket_getPort(self.sockPath, function(port){
+        self._sockFile = port;
+        self._socket.listen(port);
+      });
+      return;
+    }
+
     //
     // Create a unique socket file based on the current microtime.
     //
@@ -120,3 +128,19 @@ Worker.prototype.start = function (callback) {
   return this;
 };
 
+var nssocket_getPort;
+(function(){
+  var portfinder = require('portfinder');
+  portfinder.basePort = 37450;
+
+  nssocket_getPort = function(sockPath, callback){
+    portfinder.getPort(function(err, port){
+      if (err) throw err;
+      memorize(sockPath, port);
+      callback(port);
+    });
+  };
+  function memorize(sockPath, port){
+    fs.appendFileSync(path.join(sockPath, String(port)), '');
+  }
+}());

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "timespan": "~2.3.0",
     "watch": "~0.8.0",
     "utile": "~0.2.1",
-    "winston": "~0.7.2"
+    "winston": "~0.7.2",
+    "portfinder": "~0.2.1"
   },
   "devDependencies": {
     "broadway": "0.2.x",


### PR DESCRIPTION
Windows does not support unix socket domain connections. As so, `forever list/stop` does not work, as nssocket can not start server with the file path descriptor. This pr use ports under windows: for each task it will find first free port. 

Cheers, Alex

_Windows 8.1_
