### PR TITLE
fixes EACCESS error with .sock (UNIX domain sockets) on Windows.

### DIFF
--- a/lib/forever.js
+++ b/lib/forever.js
@@ -105,6 +105,11 @@ function getAllProcesses(callback) {
     var fullPath = path.join(sockPath, name),
         socket = new nssocket.NsSocket();
 
+    if (process.platform === 'win32') {
+      // it needs the prefix
+      fullPath = '\\\\.\\pipe\\' + fullPath;
+    }
+
     socket.connect(fullPath, function (err) {
       if (err) {
         next(err);

--- a/lib/forever/worker.js
+++ b/lib/forever/worker.js
@@ -71,6 +71,11 @@ Worker.prototype.start = function (callback) {
         self.exitOnStop && process.exit();
       });
       
+      if (process.platform === 'win32') {
+        // delete the 'symbolic' sock file
+        fs.unlink(self._sockFile);
+      }
+
       self.monitor.stop();
     });
     
@@ -110,6 +115,13 @@ Worker.prototype.start = function (callback) {
       'sock'
     ].join('.'));
     
+    if (process.platform === 'win32') {
+      // create 'symbolic' file on the system, so it can be later found (forever list)
+      fs.openSync(sock, 'w');
+      // it needs the prefix, otherwise EACCESS error happens on Windows (no .sock, only named pipes)
+      sock = '\\\\.\\pipe\\' + sock;
+    }
+
     self._socket.listen(sock);
   }
   


### PR DESCRIPTION
Windows uses named pipes instead. Thus the sufficient fix is to use the prefix, that identifies named pipe. 
The fix also creates symbolic empty .sock file, so all standard processing (forever list, stop) works as usual. When stopping, it deletes the symbolic .sock file. 
