### PR TITLE
use SVG to display Travis CI build testing status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# forever [![Build Status](https://secure.travis-ci.org/nodejitsu/forever.png)](http://travis-ci.org/nodejitsu/forever)
+# forever [![Build Status](https://api.travis-ci.org/nodejitsu/forever.svg)](http://travis-ci.org/nodejitsu/forever)
 
 A simple CLI tool for ensuring that a given script runs continuously (i.e. forever).
 


### PR DESCRIPTION
Rationale:
- SVG looks better on mobile devices with high pixel density
- SVG file size is smaller
