### PR TITLE
`file` is optional in startDaemon() if `options.command` is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ _Synchronously_ sets the specified configuration (config) for the forever module
 Starts a script with forever.
 
 ### forever.startDaemon (file, options)
-Starts a script with forever as a daemon. WARNING: Will daemonize the current process.
+Starts a script with forever as a daemon. WARNING: Will daemonize the current process. `file` field can be ommited when `options.command` is set.
 
 ### forever.stop (index)
 Stops the forever daemon script at the specified index. These indices are the same as those returned by forever.list(). This method returns an EventEmitter that raises the 'stop' event when complete.

--- a/lib/forever.js
+++ b/lib/forever.js
@@ -384,6 +384,15 @@ forever.start = function (script, options) {
 // Starts a script with forever as a daemon
 //
 forever.startDaemon = function (script, options) {
+  if (script && !Array.isArray(script) && typeof script != 'string') {
+    options = script;
+    script = undefined;
+  }
+
+  if (!script && !(options && options.command)) {
+    throw new SyntaxError("One of 'script' or 'options.command' fields must be defined")
+  }
+
   options         = options || {};
   options.uid     = options.uid || utile.randomString(4).replace(/^\-/, '_');
   options.logFile = forever.logFilePath(options.logFile || forever.config.get('logFile') || options.uid + '.log');
@@ -399,9 +408,11 @@ forever.startDaemon = function (script, options) {
   //
   outFD = fs.openSync(options.logFile, 'a');
   errFD = fs.openSync(options.logFile, 'a');
-  monitorPath = path.resolve(__dirname, '..', 'bin', 'monitor');
 
-  monitor = spawn(process.execPath, [monitorPath, script], {
+  var args = [path.resolve(__dirname, '..', 'bin', 'monitor')];
+  if(script) args.push(script);
+
+  monitor = spawn(process.execPath, args, {
     stdio: ['ipc', outFD, errFD],
     detached: true
   });


### PR DESCRIPTION
This is related with https://github.com/nodejitsu/forever-monitor/pull/73
