### PR TITLE
An 'error' on stopall is not actually an error

### DIFF
--- a/lib/forever/cli.js
+++ b/lib/forever/cli.js
@@ -307,7 +307,6 @@ app.cmd('stopall', cli.stopall = function () {
 
   runner.on('error', function () {
     forever.log.info('No forever processes running');
-    process.exit(1);
   });
 });
 


### PR DESCRIPTION
If there are no processes and `stopall` is called, don't exit with 1.
