### PR TITLE
Add --workingDir option to specify the CWD of the process in which SCRIP...

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ You can use forever to run any kind of script continuously (whether it is writte
                      eg. forever start --uid "production" app.js
                          forever stop production
     --sourceDir      The source directory for which SCRIPT is relative to
+    --workingDir     The working directory in which SCRIPT will execute
     --minUptime      Minimum uptime (millis) for a script to not be considered "spinning"
     --spinSleepTime  Time to wait (millis) between launches of a spinning script.
     --colors         --no-colors will disable output coloring

--- a/lib/forever/cli.js
+++ b/lib/forever/cli.js
@@ -54,6 +54,7 @@ var help = [
   '                   eg. forever start --uid "production" app.js',
   '                       forever stop production',
   '  --sourceDir      The source directory for which SCRIPT is relative to',
+  '  --workingDir     The working directory in which SCRIPT will execute',
   '  --minUptime      Minimum uptime (millis) for a script to not be considered "spinning"',
   '  --spinSleepTime  Time to wait (millis) between launches of a spinning script.',
   '  --colors         --no-colors will disable output coloring',
@@ -210,8 +211,8 @@ var getOptions = cli.getOptions = function (file) {
   [
     'pidFile', 'logFile', 'errFile', 'watch', 'minUptime', 'append',
     'silent', 'outFile', 'max', 'command', 'path', 'spinSleepTime',
-    'sourceDir', 'uid', 'watchDirectory', 'watchIgnore', 'killTree', 'killSignal',
-    'id'
+    'sourceDir', 'workingDir', 'uid', 'watchDirectory', 'watchIgnore',
+    'killTree', 'killSignal', 'id'
   ].forEach(function (key) {
     options[key] = app.config.get(key);
   });
@@ -235,9 +236,8 @@ var getOptions = cli.getOptions = function (file) {
   }
 
   options.sourceDir = options.sourceDir || (file && file[0] !== '/' ? process.cwd() : '/');
-  if (options.sourceDir) {
-    options.spawnWith = {cwd: options.sourceDir};
-  }
+  options.workingDir = options.workingDir || options.sourceDir;
+  options.spawnWith = {cwd: options.workingDir};
 
   return options;
 }


### PR DESCRIPTION
...T is run

This change introduces a new command line option, --workingDir, which can be used to explicitly set the working directory for the process in which the executed script is run. When --workingDir is not specified, all existing behavior remains unchanged. 

Notes:

In the existing codebase, the current working directory for a launched process will be set to '/' if the script is specified with a leading '/' (i.e., absolute path). 

The current working directory for a launched process can be influenced by setting --sourceDir. This is undocumented/potentially unexpected behavior, as the documented purpose of --sourceDir is to specify the root directory relative to which the given script path is interpreted, and makes no mention of changing the working directory.

Because the only existing way to change the working directory is to use --sourceDir, and because it is not supported to use absolute script paths when specifying --sourceDir, it is confusing and cumbersome to specify a working directory for a script when using absolute paths.

This change preserves all existing behavior if --workingDir is not specified. If --workingDir is specified, its value is used as the CWD for the script process.

More background here:
https://github.com/nodejitsu/forever/issues/270#issuecomment-61410733

Appears related to these issues:
https://github.com/nodejitsu/forever/issues/270
https://github.com/nodejitsu/forever/issues/84
