### PR TITLE
fix missing parameter

### DIFF
--- a/lib/forever.js
+++ b/lib/forever.js
@@ -255,7 +255,13 @@ function stopByPid(event, format, pid) {
     });
   }
 
-  getAllProcesses(function (processes) {
+  getAllProcesses(function (err, processes) {
+    if (err) {
+      return process.nextTick(function () {
+        emitter.emit('error', err);
+      });
+    }
+
     var procs = processes;
 
     // if we specified pid -> send action only to this process


### PR DESCRIPTION
Whenever I run `forever stopbypid 23811` (or other pid) on CLI the forever always say `error:   Forever cannot find process with pid: 23811`. I fixed this bug.
