### PR TITLE
Process exit signals on Windows

### DIFF
--- a/lib/forever.js
+++ b/lib/forever.js
@@ -60,6 +60,18 @@ forever.cli          = require('./forever/cli');
 //
 exports.version = require('../package').version;
 
+
+//
+// ### function exit ()
+// Kills child process if available and exit
+//
+function exit() {
+  if (childProcess) {
+    childProcess.stop();
+  }
+  process.exit(0);
+}
+
 //
 // ### function getSockets (sockPath, callback)
 // #### @sockPath {string} Path in which to look for UNIX domain sockets
@@ -432,7 +444,7 @@ forever.start = function (script, options) {
   //
   // Create the monitor, log events, and start.
   //
-  var monitor = new forever.Monitor(script, options);
+  var monitor = childProcess = new forever.Monitor(script, options);
   forever.logEvents(monitor);
   return monitor.start();
 };
@@ -974,6 +986,7 @@ forever.logEvents = function (monitor) {
   });
 
   monitor.on('exit:code', function (code, signal) {
+    childProcess = null;
     forever.out.error((code !== null && code !== undefined)
       ? 'Forever detected script exited with code: ' + code
       : 'Forever detected script was killed by signal: ' + signal);
@@ -1041,3 +1054,6 @@ forever.columns = {
     }
   }
 };
+
+process.on('SIGTERM', exit);
+process.on('SIGINT', exit);


### PR DESCRIPTION
Forever do not kill child process on Windows. This commit fixes it.
