### PR TITLE
Add support for option 'ignoreOkExit' in forever-monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ forever start app.js
     -t, --killTree   Kills the entire child process tree on `stop`
     --killSignal     Support exit signal customization (default is SIGKILL),
                      used for restarting script gracefully e.g. --killSignal=SIGTERM
+    --ignoreOkExit   Do not restart app if SCRIPT exits with code 0
     -h, --help       You're staring at it
 
   [Long Running Process]

--- a/lib/forever/cli.js
+++ b/lib/forever/cli.js
@@ -73,6 +73,7 @@ var help = [
   '  -t, --killTree   Kills the entire child process tree on `stop`',
   '  --killSignal     Support exit signal customization (default is SIGKILL)',
   '                   used for restarting script gracefully e.g. --killSignal=SIGTERM',
+  '  --ignoreOkExit   Do not restart app if SCRIPT exits with code 0',
   '  -h, --help       You\'re staring at it',
   '',
   '[Long Running Process]',
@@ -123,7 +124,8 @@ var argvOptions = cli.argvOptions = {
   'watch':     {alias: 'w', boolean: true},
   'debug':     {alias: 'd', boolean: true},
   'plain':     {boolean: true},
-  'uid':       {alias: 'u'}
+  'uid':       {alias: 'u'},
+  'ignoreOkExit': {boolean: true}
 };
 
 app.use(flatiron.plugins.cli, {
@@ -208,7 +210,7 @@ var getOptions = cli.getOptions = function (file) {
         'pidFile', 'logFile', 'errFile', 'watch', 'minUptime', 'append',
         'silent', 'outFile', 'max', 'command', 'path', 'spinSleepTime',
         'sourceDir', 'workingDir', 'uid', 'watchDirectory', 'watchIgnore',
-        'killTree', 'killSignal', 'id'
+        'killTree', 'killSignal', 'id', 'ignoreOkExit'
       ],
       specialKeys = ['script', 'args'],
       configs;


### PR DESCRIPTION
#### Feature:

See foreverjs/forever-monitor#128 for more information on
    this feature.

It is dependent on the mentioned PR.
#### References:

PR Full URL: https://github.com/foreverjs/forever-monitor/pull/128
