### PR TITLE
Added UID logging

### DIFF
--- a/lib/forever.js
+++ b/lib/forever.js
@@ -451,6 +451,7 @@ forever.startDaemon = function (script, options) {
 
   var monitor, outFD, errFD, monitorPath;
 
+  forever.log.info('uid for process -->',options.uid);
   //
   // This log file is forever's log file - the user's outFile and errFile
   // options are not taken into account here.  This will be an aggregate of all


### PR DESCRIPTION
While starting the script it's easy to stop the process (in case of an error) if the UID is logged while starting the process.