### PR TITLE
Document that no output is appended to the logs after forever stop/stopall is called

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ forever start app.js
     -t, --killTree   Kills the entire child process tree on `stop`
     --killSignal     Support exit signal customization (default is SIGKILL),
                      used for restarting script gracefully e.g. --killSignal=SIGTERM
+                     Any console output generated after calling `forever stop/stopall` will not appear in the logs
     -h, --help       You're staring at it
 
   [Long Running Process]


### PR DESCRIPTION
Updated version of https://github.com/foreverjs/forever/pull/642 by @arein (unfortunately I don't have access to modify original PR)