### PR TITLE
add '--version' to help text

### DIFF
--- a/lib/forever/cli.js
+++ b/lib/forever/cli.js
@@ -73,6 +73,7 @@ var help = [
   '  -t, --killTree   Kills the entire child process tree on `stop`',
   '  --killSignal     Support exit signal customization (default is SIGKILL)',
   '                   used for restarting script gracefully e.g. --killSignal=SIGTERM',
+  '  --version        Print the current version',
   '  -h, --help       You\'re staring at it',
   '',
   '[Long Running Process]',


### PR DESCRIPTION
This argument is already handled properly (see the first line of `cli.start`), but wasn't exposed in the help text.

I'm happy to change the wording if desired.