### PR TITLE
Add support for exitOnFail parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ forever start app.js
     -t, --killTree   Kills the entire child process tree on `stop`
     --killSignal     Support exit signal customization (default is SIGKILL),
                      used for restarting script gracefully e.g. --killSignal=SIGTERM
+    -x,--exitOnFail  Exits from the process when it couldn't run the script by -m times
     -h, --help       You're staring at it
 
   [Long Running Process]

--- a/lib/forever/cli.js
+++ b/lib/forever/cli.js
@@ -73,6 +73,7 @@ var help = [
   '  -t, --killTree   Kills the entire child process tree on `stop`',
   '  --killSignal     Support exit signal customization (default is SIGKILL)',
   '                   used for restarting script gracefully e.g. --killSignal=SIGTERM',
+  '  -x,--exitOnFail  Exits from the process when it couldn\'t run the script by -m times',
   '  -h, --help       You\'re staring at it',
   '',
   '[Long Running Process]',
@@ -107,23 +108,24 @@ var actions = [
 ];
 
 var argvOptions = cli.argvOptions = {
-  'command':   {alias: 'c'},
-  'errFile':   {alias: 'e'},
-  'logFile':   {alias: 'l'},
-  'killTree':  {alias: 't', boolean: true},
-  'append':    {alias: 'a', boolean: true},
-  'fifo':      {alias: 'f', boolean: true},
-  'number':    {alias: 'n'},
-  'max':       {alias: 'm'},
-  'outFile':   {alias: 'o'},
-  'path':      {alias: 'p'},
-  'help':      {alias: 'h'},
-  'silent':    {alias: 's', boolean: true},
-  'verbose':   {alias: 'v', boolean: true},
-  'watch':     {alias: 'w', boolean: true},
-  'debug':     {alias: 'd', boolean: true},
-  'plain':     {boolean: true},
-  'uid':       {alias: 'u'}
+  'command': {alias: 'c'},
+  'errFile': {alias: 'e'},
+  'logFile': {alias: 'l'},
+  'killTree': {alias: 't', boolean: true},
+  'append': {alias: 'a', boolean: true},
+  'fifo': {alias: 'f', boolean: true},
+  'number': {alias: 'n'},
+  'max': {alias: 'm'},
+  'outFile': {alias: 'o'},
+  'path': {alias: 'p'},
+  'help': {alias: 'h'},
+  'silent': {alias: 's', boolean: true},
+  'verbose': {alias: 'v', boolean: true},
+  'watch': {alias: 'w', boolean: true},
+  'debug': {alias: 'd', boolean: true},
+  'exitOnFail': {alias: 'x', boolean: true},
+  'plain': {boolean: true},
+  'uid': {alias: 'u'}
 };
 
 app.use(flatiron.plugins.cli, {
@@ -203,15 +205,15 @@ function checkColumn(name) {
 //
 var getOptions = cli.getOptions = function (file) {
   var options = {},
-      absFile = isAbsolute(file) ? file : path.resolve(process.cwd(), file),
-      configKeys = [
-        'pidFile', 'logFile', 'errFile', 'watch', 'minUptime', 'append',
-        'silent', 'outFile', 'max', 'command', 'path', 'spinSleepTime',
-        'sourceDir', 'workingDir', 'uid', 'watchDirectory', 'watchIgnore',
-        'killTree', 'killSignal', 'id'
-      ],
-      specialKeys = ['script', 'args'],
-      configs;
+    absFile = isAbsolute(file) ? file : path.resolve(process.cwd(), file),
+    configKeys = [
+      'pidFile', 'logFile', 'errFile', 'watch', 'minUptime', 'append',
+      'silent', 'outFile', 'max', 'command', 'path', 'spinSleepTime',
+      'sourceDir', 'workingDir', 'uid', 'watchDirectory', 'watchIgnore',
+      'killTree', 'killSignal', 'id', 'exitOnFail'
+    ],
+    specialKeys = ['script', 'args'],
+    configs;
 
   //
   // Load JSON configuration values
@@ -609,13 +611,22 @@ app.cmd('help', cli.help = function () {
 //
 cli.run = function () {
   var file = app.argv._[0],
-      options = getOptions(file);
+    options = getOptions(file);
+  var exitedScriptsLength = 0;
 
   options.forEach(function (o) {
     tryStart(o.script, o, function () {
       var monitor = forever.start(o.script, o);
       monitor.on('start', function () {
         forever.startServer(monitor);
+      });
+
+      monitor.on('exit', function () {
+        exitedScriptsLength++;
+
+        if (o.exitOnFail === true && exitedScriptsLength === options.length) {
+          process.exit(-1);
+        }
       });
     });
   });


### PR DESCRIPTION
That PR adds support for `--exitOnFail` or `-x` parameter.

```
node ./node_modules/.bin/forever --minUptime 1000 --spinSleepTime 1000 -m 10 -x some-script.js
``` 
When you run the forever script with that param like in the example and the `some-script.js` fails 10 times, the forever script will exit from the process with -1 code. 