### PR TITLE
Fix argument type of fs.writeFileSync

### DIFF
--- a/bin/monitor
+++ b/bin/monitor
@@ -10,7 +10,7 @@ var fs = require('fs'),
 // Write the pidFile to disk for later use
 //
 function writePid(file, pid) {
-  fs.writeFileSync(file, pid, 'utf8');
+  fs.writeFileSync(file, String(pid), 'utf8');
 }
 
 //


### PR DESCRIPTION
When I use latest master branch of nodejs which build by myself in CentOS8, I got an error 
as `TypeError [ERR_INVALID_ARG_TYPE]: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView`

From the documentation, number type is not valid for the second argument type of fs.writeFileSync.
https://nodejs.org/docs/latest-v14.x/api/fs.html#fs_fs_writefilesync_file_data_options

I'm not sure if this problem exists in other versions, but at least, it's better to fix it from the documentation.