### PR TITLE
Add Winston config option to prevent stray 'undefined' in output

### DIFF
--- a/lib/forever.js
+++ b/lib/forever.js
@@ -67,7 +67,9 @@ forever.log = winston.createLogger({
     new (winston.transports.Console)()
   ],
   levels: winston.config.cli.levels,
-  format: winston.format.cli(),
+  format: winston.format.cli({
+    levels: winston.config.cli.levels,
+  }),
 });
 
 //


### PR DESCRIPTION
issue reported here: https://github.com/foreversd/forever/pull/1128#issuecomment-1025476725