### PR TITLE
Remove Node 6 from CI; looks like it's been EOL for a couple years

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,11 +25,6 @@ commands:
           paths:
             - ~/.npm/_cacache
 jobs:
-  node-v6:
-    docker:
-      - image: node:6
-    steps:
-      - test-nodejs
   node-v8:
     docker:
       - image: node:8
@@ -60,7 +55,6 @@ workflows:
   version: 2
   node-multi-build:
     jobs:
-      - node-v6
       - node-v8
       - node-v10
       - node-v12


### PR DESCRIPTION
seemed like a nice way to save a few CPU cycles