### PR TITLE
Update colors to maintained version

### DIFF
--- a/lib/forever/cli.js
+++ b/lib/forever/cli.js
@@ -9,7 +9,7 @@
 var fs = require('fs'),
     path = require('path'),
     util = require('util'),
-    colors = require('colors'),
+    colors = require('@colors/colors'),
     cliff = require('cliff'),
     flatiron = require('flatiron'),
     shush = require('shush'),

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "async": "^1.5.2",
     "cliff": "^0.1.10",
     "clone": "^2.1.2",
-    "colors": "0.6.2",
+    "@colors/colors": "1.5.0",
     "configstore": "4.0.0",
     "eventemitter2": "6.4.4",
     "flatiron": "~0.4.3",


### PR DESCRIPTION
Per https://github.com/Marak/colors.js/issues/340, the `colors` package on which `forever` depends has been migrated to `@colors/colors`.  This PR performs the (very simple) migration.  Thanks for your help with getting this into the next release, and let me know if you need any help with getting this fix out or other maintenance tasks.